### PR TITLE
Fix a crash on deauth.

### DIFF
--- a/ios/MobilePaymentsSdkReactNative.swift
+++ b/ios/MobilePaymentsSdkReactNative.swift
@@ -40,8 +40,10 @@ class MobilePaymentsSdkReactNative: RCTEventEmitter {
     // Deauthorize
     @objc(deauthorize:withRejecter:)
     func deauthorize(resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-        mobilePaymentsSDK.authorizationManager.deauthorize {
-            resolve("Square Mobile Payments SDK successfully deauthorized.")
+        DispatchQueue.main.async { [weak self] in
+            self?.mobilePaymentsSDK.authorizationManager.deauthorize {
+                resolve("Square Mobile Payments SDK successfully deauthorized.")
+            }
         }
     }
 


### PR DESCRIPTION
The crash happens due to a method observing card readers trying to stop observing while deauth is happening in a background thread. Moving this call to the main thread fixes this.