### PR TITLE
Update README.md to mention Proguard

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,12 +39,23 @@ fi
 
 Make sure this build phase is after any `[CP] Embed Pods Frameworks` or `Embed Frameworks` Build Phase.
 
-For Android, you need to configure the SDK version:
+For Android:
 1. Modify your `/android/build.gradle`
    - Add `squareSdkVersion = "2.0.2"` inside the `ext {...}` block
    - Add `maven { url 'https://sdk.squareup.com/public/android/' }` inside the `allprojects`'s `repositories {...}` block
 2. Modify your `/android/app/build.gradle`
    - Add `implementation("com.squareup.sdk:mobile-payments-sdk:$squareSdkVersion")` inside the `dependencies{...}` block
+3. Disable Proguard by adding the following to your `/android/app/build.gradle`:
+```gradle
+android {
+    buildTypes {
+        release {
+            minifyEnabled false
+            shrinkResources false
+        }
+    }
+}
+```
 
 You can also refer to [MPSDK Android Quickstart](https://developer.squareup.com/docs/mobile-payments-sdk/android#1-install-the-sdk-and-dependencies)'s SDK installation section.
 


### PR DESCRIPTION
Mobile Payment SDK doesn't support Proguard for code optimization, as it might remove some critical bytecode from the library. This PR updates README.md to mention the required configuration