### PR TITLE
Typing fixes + `OfflinePayment` naming fix

### DIFF
--- a/src/managers/auth.ts
+++ b/src/managers/auth.ts
@@ -9,8 +9,8 @@ export let authorizationObserver: EmitterSubscription;
 
 // Authorization: https://developer.squareup.com/docs/mobile-payments-sdk/ios/configure-authorize
 export const authorize = (
-  accessToken: String,
-  locationId: String
+  accessToken: string,
+  locationId: string
 ): Promise<String> => {
   return MobilePaymentsSdkReactNative.authorize(accessToken, locationId);
 };

--- a/src/managers/payment.ts
+++ b/src/managers/payment.ts
@@ -1,7 +1,7 @@
 import MobilePaymentsSdkReactNative from '../base_sdk';
 import type {
   Money,
-  OffLinePayment,
+  OfflinePayment,
   Payment,
   PaymentParameters,
   PromptParameters,
@@ -23,7 +23,7 @@ export const cancelPayment = (): Promise<void> => {
 };
 
 export namespace OfflinePaymentQueue {
-  export const getPayments = (): Promise<OffLinePayment[]> => {
+  export const getPayments = (): Promise<OfflinePayment[]> => {
     return MobilePaymentsSdkReactNative.getPayments();
   };
 

--- a/src/managers/reader.ts
+++ b/src/managers/reader.ts
@@ -31,11 +31,11 @@ export const isPairingInProgress = (): Promise<boolean> => {
   return MobilePaymentsSdkReactNative.isPairingInProgress();
 };
 
-const addReaderChangedCallback = (refId: String): Promise<String> => {
+const addReaderChangedCallback = (refId: string): Promise<String> => {
   return MobilePaymentsSdkReactNative.addReaderChangedCallback(refId);
 };
 
-const removeReaderChangedCallback = (refId: String): Promise<void> => {
+const removeReaderChangedCallback = (refId: string): Promise<void> => {
   return MobilePaymentsSdkReactNative.removeReaderChangedCallback(refId);
 };
 
@@ -109,6 +109,6 @@ export namespace TapToPaySettings {
   };
 }
 
-const generateUUID = (): String => {
+const generateUUID = (): string => {
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
 };

--- a/src/models/errors.ts
+++ b/src/models/errors.ts
@@ -69,21 +69,21 @@ export enum ReaderPairingError {
 // Corresponds to the ErrorDetails inside the Failure object in the SDK
 // Android: https://square.github.io/mobile-payments-sdk-android/-mobile%20-payments%20-s-d-k%20-android%20-technical%20-reference/com.squareup.sdk.mobilepayments.core/-error-details/index.html
 export type ErrorDetails = {
-  category: String;
-  code: String;
-  detail: String;
-  field: String;
+  category: string;
+  code: string;
+  detail: string;
+  field: string;
 };
 
 // Corresponds to the Failure object in the SDK
 // Android: https://square.github.io/mobile-payments-sdk-android/-mobile%20-payments%20-s-d-k%20-android%20-technical%20-reference/com.squareup.sdk.mobilepayments.core/-result/-failure/index.html
 // iOS: https://developer.apple.com/documentation/foundation/nserror
 export type Failure = {
-  debugMessage: String;
-  debugCode: String;
+  debugMessage: string;
+  debugCode: string;
   details: ErrorDetails[];
-  errorMessage: String;
-  errorCode: String;
+  errorMessage: string;
+  errorCode: string;
 };
 
 // Convenience function to map the error.userInfo object to a Failure object

--- a/src/models/objects.ts
+++ b/src/models/objects.ts
@@ -10,6 +10,7 @@ import type {
   EntryMethod,
   OfflinePaymentStatus,
   PaymentStatus,
+  ProcessingMode,
   PromptMode,
   ReaderBatteryLevel,
   ReaderChange,
@@ -24,14 +25,14 @@ import type {
 } from './enums';
 
 export type Location = {
-  id: String;
-  currencyCode: String;
-  name: String;
-  mcc: String;
+  id: string;
+  currencyCode: string;
+  name: string;
+  mcc: string;
 };
 
 export type Money = {
-  amount?: Number;
+  amount?: number;
   currencyCode: CurrencyCode;
 };
 
@@ -40,28 +41,28 @@ export type OnlinePayment = {
   appFeeMoney: Money;
   cardDetails: CardPaymentDetails;
   createdAt: Date;
-  customerId: String;
-  id: String;
-  locationId: String;
-  note: String;
-  orderId: String;
-  referenceId: String;
+  customerId: string;
+  id: string;
+  locationId: string;
+  note: string;
+  orderId: string;
+  referenceId: string;
   status: PaymentStatus;
   tipMoney: Money;
   totalMoney: Money;
   updatedAt: Date;
 };
 
-export type OffLinePayment = {
+export type OfflinePayment = {
   amountMoney: Money;
   appFeeMoney: Money;
   cardDetails: OfflineCardPaymentDetails;
   createdAt: Date;
-  id: String;
-  localId: String;
-  locationId: String;
-  orderId: String;
-  referenceId: String;
+  id: string;
+  localId: string;
+  locationId: string;
+  orderId: string;
+  referenceId: string;
   status: OfflinePaymentStatus;
   sourceType: SourceType;
   tipMoney: Money;
@@ -73,58 +74,58 @@ export type OffLinePayment = {
 export type PaymentParameters = {
   // Required
   amountMoney: Money;
-  processingMode: Number;
+  processingMode: ProcessingMode;
   // Optional. For defaults, check:
   // Android: https://square.github.io/mobile-payments-sdk-android/-mobile%20-payments%20-s-d-k%20-android%20-technical%20-reference/com.squareup.sdk.mobilepayments.payment/-payment-parameters/index.html
   // iOS: https://square.github.io/mobile-payments-sdk-ios/docs/documentation/mobilepaymentssdkapi/paymentparameters/
-  acceptPartialAuthorization?: Boolean;
+  acceptPartialAuthorization?: boolean;
   appFeeMoney?: Money;
-  autocomplete?: Boolean;
-  customerId?: String;
+  autocomplete?: boolean;
+  customerId?: string;
   delayAction?: DelayAction;
-  delayDuration?: Number;
-  locationId?: String;
-  note?: String;
-  orderId?: String;
-  referenceId?: String;
-  statementDescriptionIdentifer?: String;
-  teamMemberId?: String;
+  delayDuration?: number;
+  locationId?: string;
+  note?: string;
+  orderId?: string;
+  referenceId?: string;
+  statementDescriptionIdentifer?: string;
+  teamMemberId?: string;
   tipMoney?: Money;
   totalMoney?: Money;
-  idempotencyKey?: String;
-  paymentAttemptId?: String;
+  idempotencyKey?: string;
+  paymentAttemptId?: string;
 };
 
 export type Card = {
   brand: CardBrand;
-  cardholderName: String;
+  cardholderName: string;
   coBrand: CardCoBrand;
-  expirationMonth?: Number;
-  expirationYear?: Number;
-  id: String;
-  lastFourDigits: String;
+  expirationMonth?: number;
+  expirationYear?: number;
+  id: string;
+  lastFourDigits: string;
 };
 
 export type CardPaymentDetails = {
-  applicationIdentifier: String;
-  applicationName: String;
-  authorizationCode: String;
+  applicationIdentifier: string;
+  applicationName: string;
+  authorizationCode: string;
   card: Card;
   entryMethod: EntryMethod;
   status: CardPaymentStatus;
 };
 
 export type OfflineCardPaymentDetails = {
-  applicationIdentifier: String;
-  applicationName: String;
+  applicationIdentifier: string;
+  applicationName: string;
   card: Card;
   entryMethod: EntryMethod;
 };
 
 export type CardInputMethods = {
-  chip: Boolean;
-  contactless: Boolean;
-  swipe: Boolean;
+  chip: boolean;
+  contactless: boolean;
+  swipe: boolean;
 };
 
 export type PromptParameters = {
@@ -136,10 +137,10 @@ export type Payment = {
   amountMoney: Money;
   appFeeMoney: Money;
   createdAt: Date;
-  id: String;
-  locationId: String;
-  orderId: String;
-  referenceId: String;
+  id: string;
+  locationId: string;
+  orderId: string;
+  referenceId: string;
   sourceType: SourceType;
   tipMoney: Money;
   totalMoney: Money;
@@ -147,15 +148,15 @@ export type Payment = {
 };
 
 export type ReaderBatteryStatus = {
-  isCharging: Boolean;
+  isCharging: boolean;
   level?: ReaderBatteryLevel;
-  percent: Number;
+  percent: number;
 };
 
 export type ReaderConnectionFailureInfo = {
   failureReason: ReaderConnectionFailureReason;
-  localizedDescription: String;
-  localizedTitle: String;
+  localizedDescription: string;
+  localizedTitle: string;
   recoverySuggestion: ReaderConnectionFailureRecoverySuggestion;
 };
 
@@ -165,9 +166,9 @@ export type ReaderConnectionInfo = {
 };
 
 export type ReaderFirmwareInfo = {
-  failureReason?: String;
-  updatePercentage: Number;
-  version: String;
+  failureReason?: string;
+  updatePercentage: number;
+  version: string;
 };
 
 export type ReaderStatus = {
@@ -176,28 +177,28 @@ export type ReaderStatus = {
 };
 
 export type ReaderInfo = {
-  id: String;
+  id: string;
   model: ReaderModel;
   state: ReaderState;
   status: ReaderStatus;
-  serialNumber?: String;
-  name: String;
+  serialNumber?: string;
+  name: string;
   batteryStatus?: ReaderBatteryStatus;
-  firmwareVersion?: String;
-  firmwarePercent?: Number;
+  firmwareVersion?: string;
+  firmwarePercent?: number;
   supportedCardEntryMethods: CardEntryMethod[];
-  isForgettable: Boolean;
-  isBlinkable: Boolean;
+  isForgettable: boolean;
+  isBlinkable: boolean;
 
   cardInsertionStatus?: CardInsertionStatus;
   connectionInfo?: ReaderConnectionInfo;
   firmwareInfo?: ReaderFirmwareInfo;
-  isConnectionRetryable?: Boolean;
+  isConnectionRetryable?: boolean;
 };
 
 export type ReaderChangedEvent = {
   change: ReaderChange;
   reader: ReaderInfo;
   readerState: ReaderState;
-  readerSerialNumber?: String;
+  readerSerialNumber?: string;
 };


### PR DESCRIPTION
I change all instances of `Number`, `String`, and `Boolean` to `number`, `string`, and `boolean` respectively, as well as fixing a typo in the name of `OfflinePayment` (previously `OffLinePayment`). Changing e.g. `Number` to `number` fixes issues when trying to instantiate e.g. a payment using a regular old number value. This is also true for the other type fixes.