### PR TITLE
V2026.7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
             ${{ runner.os }}-cocoapods-
 
       - name: Install cocoapods
-        if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit != 'true'
+        if: env.turbo_cache_hit != 1
         run: |
           cd example/ios
           pod install

--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -22,7 +22,8 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install -g npm@latest
+      # npm 12+ requires Node 22+; pin to 11 for Node 20 while keeping OIDC/provenance support
+      - run: npm install -g npm@11
       - run: npm i --ignore-scripts
       - run: npm pack
       - run: npm publish --provenance --access public

--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -24,6 +24,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       # npm 12+ requires Node 22+; pin to 11 for Node 20 while keeping OIDC/provenance support
       - run: npm install -g npm@11
-      - run: npm i --ignore-scripts
+      # Yarn workspaces use link: (e.g. example-expo); npm cannot resolve that protocol
+      - run: corepack enable
+      - run: yarn install --immutable --mode=skip-build
+      - run: yarn prepare
       - run: npm pack
       - run: npm publish --provenance --access public

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1823,7 +1823,7 @@ SPEC CHECKSUMS:
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: 69ef571f3de08433d766d614c73a9838a06bf7eb
   hermes-engine: 8d2103d6c0176779aea4e25df6bb1410f9946680
-  mobile-payments-sdk-react-native: 5043e9739abac95242a248e3fa6764020767cb56
+  mobile-payments-sdk-react-native: 0127c776080d69197430521a51c9e6061f00d0fc
   MockReaderUI: f920dd06eaa41846b5c033da4bc01993b5ad4e50
   Permission-BluetoothPeripheral: 34ab829f159c6cf400c57bac05f5ba1b0af7a86e
   Permission-LocationAccuracy: 30c5421911024b28d8916db5cbd728097da54434

--- a/mobile-payments-sdk-react-native.podspec
+++ b/mobile-payments-sdk-react-native.podspec
@@ -18,6 +18,10 @@ Pod::Spec.new do |s|
   s.dependency "SquareMobilePaymentsSDK", "~> 2.6.0"
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
+  # Exclude local CocoaPods output from the standalone ios/ Xcode project.
+  # Without this, stale SquareMobilePaymentsSDK headers get compiled into this
+  # module and clash with the real 2.x framework ("different definitions in different modules").
+  s.exclude_files = "ios/Pods/**/*"
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
- Fix npm publish on Node 20 (pin npm@11; install/build with Yarn because of link: workspaces)
- Exclude ios/Pods from the podspec so stale SDK headers don’t break iOS builds
- Always pod install in CI when turbo cache misses