### PR TITLE
Bump Android native SDK to 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v2026.8.1 Aug 24, 2026
+
+* Upgrade Android native SDK to `2.6.1`, which fixes a bug where Tap to Pay on Android became unavailable for up to 2 hours before the daily payment-key rotation
+
 ### v2026.7.1 Jul 28, 2026
 
 - Upgrade Android and iOS native SDK to `2.6.0`. See the native changelog: [https://developer.squareup.com/docs/changelog/mobile-logs/2026-07-27](https://developer.squareup.com/docs/changelog/mobile-logs/2026-07-27)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Mobile Payments SDK for React Native supports the following SDK versions:
 
   * [iOS](https://developer.squareup.com/docs/mobile-payments-sdk/ios#1-install-the-sdk-and-dependencies): 2.6.0 and above
-  * [Android](https://developer.squareup.com/docs/mobile-payments-sdk/android#1-install-the-sdk-and-dependencies): 2.6.0 and above
+  * [Android](https://developer.squareup.com/docs/mobile-payments-sdk/android#1-install-the-sdk-and-dependencies): 2.6.1 and above
 
 ## Review requirements
 Before getting started, please review the Requirements and Limitations and Device Compatibility sections to ensure that the SDK can be used in your project:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -88,7 +88,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault("kotlinVersion")
-def squareSdkVersion = "2.6.0"
+def squareSdkVersion = "2.6.1"
 
 dependencies {
   // For < 0.71, this will be from the local maven repo

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,7 @@ Make sure this build phase is after any `[CP] Embed Pods Frameworks` or `Embed F
 
 For Android:
 1. Modify your `/android/build.gradle`
-   - Add `squareSdkVersion = "2.6.0"` inside the `ext {...}` block
+   - Add `squareSdkVersion = "2.6.1"` inside the `ext {...}` block
    - Set `compileSdkVersion = 36` (or higher) and use Android Gradle Plugin `8.9.1` or higher with Gradle `8.13` or higher, as required by `androidx.core:core:1.18.0`
    - Add `maven { url 'https://sdk.squareup.com/public/android/' }` inside the `allprojects`'s `repositories {...}` block
 2. Modify your `/android/app/build.gradle`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-payments-sdk-react-native",
-  "version": "2026.7.1",
+  "version": "2026.8.1",
   "description": "Mobile Payments SDK plug-in for React Native. Enables developers to build secure in-person payment solutions.",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
## Description

Android-only patch release bump: native SDK [2.6.1](https://github.com/square/mobile-payments-sdk-android/releases/tag/2.6.1) fixes a bug where Tap to Pay on Android became unavailable for up to 2 hours before the daily payment-key rotation. iOS stays on 2.6.0.

## Changes

- Bump `squareSdkVersion` to `2.6.1` in `android/build.gradle`
- Update README supported versions (Android: 2.6.1 and above)
- Update `squareSdkVersion` in the docs setup instructions
- Add `v2026.8.1` changelog entry and bump `package.json` version to `2026.8.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)